### PR TITLE
Make is_bidi support arabic by making it test for bc=AL as well

### DIFF
--- a/lib/Text/Bidi.pm
+++ b/lib/Text/Bidi.pm
@@ -584,7 +584,7 @@ helps if we want to short-circuit.
 
 =cut
 
-sub is_bidi { $_[0] =~ /\p{bc=R}/ }
+sub is_bidi { $_[0] =~ /\p{bc=R}|\p{bc=AL}/ }
 
 =func get_mirror_char()
 

--- a/t/is_bidi.t
+++ b/t/is_bidi.t
@@ -1,0 +1,9 @@
+use strict;
+use warnings;
+use charnames ":full";
+use Test::More tests => 3;
+use Text::Bidi qw(is_bidi);
+
+ok is_bidi("\N{HEBREW LETTER AYIN}"), "hebrew is bidi";
+ok is_bidi("\N{ARABIC LETTER AIN}"), "arabic is bidi";
+ok ! is_bidi("A"), "latin is not bidi";


### PR DESCRIPTION
The bc=R unicode property is unset on arabic characters; instead they have the bc=AL (aka Bidi_Class=Arabic_Letter) property set. Make is_bidi look for either property.

```perl
use charnames ':full';
use Test::More tests => 4;
like "\N{HEBREW LETTER AYIN}", qr/\p{bc=R}/;
unlike "\N{HEBREW LETTER AYIN}", qr/\p{bc=AL}/;
unlike "\N{ARABIC LETTER AIN}", qr/\p{bc=R}/;
like "\N{ARABIC LETTER AIN}", qr/\p{bc=AL}/;
```

This change was necessary for me to get the urxvt plugin to be able to display arabic properly.

Thanks for making that possible to get working :)